### PR TITLE
feat(metadata): add parameters_b and publish_date to all models

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -10,70 +10,94 @@ claude-opus-4.5:
   model_id: claude-opus-4-5-20251101
   reasoning_budget: 16000  # budget_tokens for extended thinking
   color: "#C1755A"  # Anthropic warm
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-11"
 
 claude-haiku-4.5:
   provider: anthropic
   model_id: claude-haiku-4-5-20251001
   reasoning_budget: 16000  # budget_tokens for extended thinking
   color: "#D08E76"  # Anthropic warm (lighter)
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-10"
 
 gpt-5-mini-medium:
   provider: openai
   model_id: gpt-5-mini-2025-08-07
   reasoning_effort: medium  # none|minimal|low|medium|high|xhigh
   color: "#99BDB4"  # OpenAI teal
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-08"
 
 gpt-5.2-medium:
   provider: openai
   model_id: gpt-5.2
   reasoning_effort: medium  # none|minimal|low|medium|high|xhigh
   color: "#99BDB4"  # OpenAI teal (lightest)
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-12"  # released Dec 11, 2025
 
 gpt-5.2-high:
   provider: openai
   model_id: gpt-5.2
   reasoning_effort: high  # none|minimal|low|medium|high|xhigh
   color: "#8CB3A8"  # OpenAI teal
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-12"  # released Dec 11, 2025
 
 gpt-5.2-xhigh:
   provider: openai
   model_id: gpt-5.2
   reasoning_effort: xhigh  # none|minimal|low|medium|high|xhigh
   color: "#7FA99D"  # OpenAI teal (darkest)
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-12"  # released Dec 11, 2025
 
 gemini-3-pro-preview-low:
   provider: google
   model_id: gemini-3-pro-preview
   thinking_level: low
   color: "#6E97F3"  # Gemini blue (lighter)
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-11"  # released Nov 18, 2025
 
 gemini-3-pro-preview-high:
   provider: google
   model_id: gemini-3-pro-preview
   thinking_level: high
   color: "#4E81F0"  # Gemini blue
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-11"  # released Nov 18, 2025
 
 gemini-3-flash-preview-low:
   provider: google
   model_id: gemini-3-flash-preview
   thinking_level: low
   color: "#AEC3F9"  # Gemini blue (lightest)
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-12"  # released Dec 17, 2025
 
 gemini-3-flash-preview-high:
   provider: google
   model_id: gemini-3-flash-preview
   thinking_level: high
   color: "#8EADF6"  # Gemini blue (lighter)
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-12"  # released Dec 17, 2025
 
 grok-4-1-fast-reasoning:
   provider: xai
   model_id: grok-4-1-fast-reasoning
   color: "#1A1A1A"  # xAI black
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-11"  # released Nov 20, 2025
 
 grok-4:
   provider: xai
   model_id: grok-4
   color: "#333333"  # xAI dark gray
+  parameters_b: null  # not publicly disclosed
+  publish_date: "2025-07"  # released Jul 10, 2025
 
 # ============================================================================
 # OpenRouter - SLM models (< 9B parameters)
@@ -84,32 +108,44 @@ ministral-8b:
   provider: openrouter
   model_id: mistralai/ministral-8b-2512
   color: "#FF7043"  # Mistral orange
+  parameters_b: 8.0  # Ministral 3 8B
+  publish_date: "2025-12"  # released Dec 2, 2025
 
 # Standard SLM instruction models
 llama-3.1-8b:
   provider: openrouter
   model_id: meta-llama/llama-3.1-8b-instruct
   color: "#5BA8FB"  # Meta blue
+  parameters_b: 8.0
+  publish_date: "2024-07"  # released Jul 23, 2024
 
 qwen-2.5-7b:
   provider: openrouter
   model_id: qwen/qwen-2.5-7b-instruct
   color: "#E07B54"  # Qwen orange
+  parameters_b: 7.6
+  publish_date: "2024-09"  # released Sep 19, 2024
 
 gemma-3-4b:
   provider: openrouter
   model_id: google/gemma-3-4b-it
   color: "#82B4F7"  # Google blue (light)
+  parameters_b: 4.3
+  publish_date: "2025-03"  # released Mar 12, 2025
 
 qwen-3-8b:
   provider: openrouter
   model_id: qwen/qwen3-8b
   color: "#D4622A"  # Qwen orange (dark)
+  parameters_b: 8.2
+  publish_date: "2025-04"  # released Apr 28, 2025
 
 llama-3.2-3b:
   provider: openrouter
   model_id: meta-llama/llama-3.2-3b-instruct
   color: "#5BA8FB"  # Meta blue (light)
+  parameters_b: 3.2
+  publish_date: "2024-09"  # released Sep 25, 2024
 
 # ============================================================================
 # Open Models - HuggingFace Inference Providers
@@ -121,6 +157,8 @@ deepseek-r1:
   hf_provider: together
   reasoning_format: think_tags  # Uses <think>...</think> in content
   color: "#5A6AF7"  # DeepSeek blue-violet
+  parameters_b: 671.0  # MoE total, 37B active
+  publish_date: "2025-01"  # released Jan 20, 2025
 
 kimi-k2:
   provider: huggingface
@@ -128,6 +166,8 @@ kimi-k2:
   hf_provider: together
   reasoning_format: separate_field
   color: "#CCCC00"  # Yellow
+  parameters_b: 1000.0  # MoE total (~1T), 32B active
+  publish_date: "2025-07"  # released Jul 11, 2025
 
 glm-4.7:
   provider: huggingface
@@ -135,6 +175,8 @@ glm-4.7:
   hf_provider: zai-org
   reasoning_format: separate_field
   color: "#FF7777"  # red-pink
+  parameters_b: 355.0  # MoE total, 32B active
+  publish_date: "2025-12"  # released Dec 22, 2025
 
 gpt-oss-120b:
   provider: huggingface
@@ -142,6 +184,8 @@ gpt-oss-120b:
   hf_provider: together
   reasoning_format: separate_field
   color: "#707070"  # Dark gray
+  parameters_b: 117.0  # MoE total, 5.1B active
+  publish_date: "2025-08"  # released Aug 5, 2025
 
 gpt-oss-20b:
   provider: huggingface
@@ -149,6 +193,8 @@ gpt-oss-20b:
   hf_provider: together
   reasoning_format: separate_field
   color: "#B2B2B2"  # Light gray
+  parameters_b: 21.0  # MoE total, 3.6B active
+  publish_date: "2025-08"  # released Aug 5, 2025
 
 # ============================================================================
 # Local Models - OpenAI-compatible servers
@@ -173,6 +219,8 @@ local-ollama-qwen3.5-9b:
   base_url: http://localhost:11434/v1
   reasoning_format: think_tags
   color: "#7C3AED"
+  parameters_b: 9.0
+  publish_date: "2026-03"  # released Mar 2, 2026
 
 # ollama pull qwen3.5:4b
 local-ollama-qwen3.5-4b:
@@ -181,3 +229,5 @@ local-ollama-qwen3.5-4b:
   base_url: http://localhost:11434/v1
   reasoning_format: think_tags
   color: "#6D28D9"
+  parameters_b: 4.0
+  publish_date: "2026-03"  # released Mar 2, 2026

--- a/src/eleusis/analysis/basic_metrics.py
+++ b/src/eleusis/analysis/basic_metrics.py
@@ -608,6 +608,185 @@ def plot_score_stack(
     return png_path, json_path
 
 
+def plot_score_vs_parameters(
+    metrics: pd.DataFrame, model_colors: dict[str, str], output_folder: Path
+) -> tuple[Path, Path]:
+    """Generate scatter plot of avg_floored_score vs number of billion parameters.
+
+    Only includes models with known parameters_b.
+    Returns (png_path, json_path).
+    """
+    setup_matplotlib_style()
+    fig, ax = plt.subplots(figsize=(10, 8))
+
+    model_metadata = load_model_metadata()
+
+    plot_data = {
+        "models": [],
+        "metadata": {"x_axis": "parameters_b", "y_axis": "avg_floored_score"},
+    }
+
+    for _, row in metrics.iterrows():
+        model_name = row["model"]
+        y = row["avg_floored_score"]
+        color = get_model_color(model_name, model_colors)
+
+        parameters_b = None
+        is_open = False
+        provider = "unknown"
+        normalized_name = normalize_model_name(model_name)
+        for key, meta in model_metadata.items():
+            norm_key = normalize_model_name(key)
+            if norm_key == normalized_name or norm_key in normalized_name or normalized_name in norm_key:
+                parameters_b = meta.get("parameters_b")
+                is_open = meta["is_open"]
+                provider = meta["provider"]
+                break
+
+        if parameters_b is None:
+            continue
+
+        if is_open:
+            ax.scatter(parameters_b, y, c="none", edgecolors=color, s=150, linewidths=2.5, zorder=3)
+        else:
+            ax.scatter(parameters_b, y, c=color, s=150, alpha=0.9, zorder=3)
+
+        ax.annotate(
+            model_name, (parameters_b, y),
+            xytext=(8, 4), textcoords="offset points", fontsize=9,
+            ha="left", va="bottom"
+        )
+
+        plot_data["models"].append({
+            "name": model_name,
+            "avg_floored_score": float(y),
+            "parameters_b": float(parameters_b),
+            "color": color,
+            "is_open": is_open,
+            "provider": provider,
+        })
+
+    ax.set_xscale("log")
+    ax.set_xlabel("Number of Parameters (Billions, log scale)", fontsize=11)
+    ax.set_ylabel("Average Floored Score", fontsize=11)
+    ax.set_title("Performance vs Model Size", fontsize=13, fontweight="bold")
+
+    from matplotlib.lines import Line2D
+    legend_elements = [
+        Line2D([0], [0], marker="o", color="w", markerfacecolor="gray", markersize=10, label="Closed model"),
+        Line2D([0], [0], marker="o", color="w", markerfacecolor="none", markeredgecolor="gray",
+               markeredgewidth=2, markersize=10, label="Open model"),
+    ]
+    ax.legend(handles=legend_elements, loc="lower right", fontsize=10)
+
+    png_path = output_folder / "score_vs_parameters.png"
+    json_path = output_folder / "score_vs_parameters.json"
+
+    save_figure(fig, png_path)
+    with open(json_path, "w") as f:
+        json.dump(plot_data, f, indent=2)
+    logger.info(f"Saved: {json_path}")
+
+    return png_path, json_path
+
+
+def plot_score_vs_publish_date(
+    metrics: pd.DataFrame, model_colors: dict[str, str], output_folder: Path
+) -> tuple[Path, Path]:
+    """Generate scatter plot of avg_floored_score vs publish date.
+
+    Only includes models with known publish_date (format "YYYY-MM").
+    Returns (png_path, json_path).
+    """
+    setup_matplotlib_style()
+    fig, ax = plt.subplots(figsize=(12, 8))
+
+    model_metadata = load_model_metadata()
+
+    plot_data = {
+        "models": [],
+        "metadata": {"x_axis": "publish_date", "y_axis": "avg_floored_score"},
+    }
+
+    for _, row in metrics.iterrows():
+        model_name = row["model"]
+        y = row["avg_floored_score"]
+        color = get_model_color(model_name, model_colors)
+
+        publish_date = None
+        is_open = False
+        provider = "unknown"
+        normalized_name = normalize_model_name(model_name)
+        for key, meta in model_metadata.items():
+            norm_key = normalize_model_name(key)
+            if norm_key == normalized_name or norm_key in normalized_name or normalized_name in norm_key:
+                publish_date = meta.get("publish_date")
+                is_open = meta["is_open"]
+                provider = meta["provider"]
+                break
+
+        if publish_date is None:
+            continue
+
+        # Convert "YYYY-MM" to a numeric value for plotting (year + month/12)
+        year, month = map(int, publish_date.split("-"))
+        x = year + (month - 1) / 12.0
+
+        if is_open:
+            ax.scatter(x, y, c="none", edgecolors=color, s=150, linewidths=2.5, zorder=3)
+        else:
+            ax.scatter(x, y, c=color, s=150, alpha=0.9, zorder=3)
+
+        ax.annotate(
+            model_name, (x, y),
+            xytext=(8, 4), textcoords="offset points", fontsize=9,
+            ha="left", va="bottom"
+        )
+
+        plot_data["models"].append({
+            "name": model_name,
+            "avg_floored_score": float(y),
+            "publish_date": publish_date,
+            "color": color,
+            "is_open": is_open,
+            "provider": provider,
+        })
+
+    ax.set_xlabel("Publish Date", fontsize=11)
+    ax.set_ylabel("Average Floored Score", fontsize=11)
+    ax.set_title("Performance vs Publish Date", fontsize=13, fontweight="bold")
+
+    import matplotlib.ticker as ticker
+
+    def format_date(x, _):
+        year = int(x)
+        month = round((x - year) * 12) + 1
+        return f"{year}-{month:02d}"
+
+    ax.xaxis.set_major_formatter(ticker.FuncFormatter(format_date))
+    plt.xticks(rotation=45, ha="right")
+
+    from matplotlib.lines import Line2D
+    legend_elements = [
+        Line2D([0], [0], marker="o", color="w", markerfacecolor="gray", markersize=10, label="Closed model"),
+        Line2D([0], [0], marker="o", color="w", markerfacecolor="none", markeredgecolor="gray",
+               markeredgewidth=2, markersize=10, label="Open model"),
+    ]
+    ax.legend(handles=legend_elements, loc="lower right", fontsize=10)
+
+    plt.tight_layout()
+
+    png_path = output_folder / "score_vs_publish_date.png"
+    json_path = output_folder / "score_vs_publish_date.json"
+
+    save_figure(fig, png_path)
+    with open(json_path, "w") as f:
+        json.dump(plot_data, f, indent=2)
+    logger.info(f"Saved: {json_path}")
+
+    return png_path, json_path
+
+
 def analyze_basic_metrics(
     df_rounds: pd.DataFrame,
     df_turns: pd.DataFrame,
@@ -652,5 +831,15 @@ def analyze_basic_metrics(
 
     # Generate score stack plot (raw -> floored -> no-stakes)
     png_path, json_path = plot_score_stack(metrics, model_colors, output_folder)
+    tee.write(f"Saved: {png_path}\n")
+    tee.write(f"Saved: {json_path}\n")
+
+    # Generate score vs parameters plot (only models with known parameters_b)
+    png_path, json_path = plot_score_vs_parameters(metrics, model_colors, output_folder)
+    tee.write(f"Saved: {png_path}\n")
+    tee.write(f"Saved: {json_path}\n")
+
+    # Generate score vs publish date plot (only models with known publish_date)
+    png_path, json_path = plot_score_vs_publish_date(metrics, model_colors, output_folder)
     tee.write(f"Saved: {png_path}\n")
     tee.write(f"Saved: {json_path}\n")

--- a/src/eleusis/analysis/colors.py
+++ b/src/eleusis/analysis/colors.py
@@ -35,6 +35,8 @@ def load_model_metadata() -> dict[str, dict]:
                 "color": config.get("color", DEFAULT_COLOR),
                 "is_open": provider in OPEN_PROVIDERS,
                 "provider": provider,
+                "parameters_b": config.get("parameters_b"),
+                "publish_date": config.get("publish_date"),
             }
     return metadata
 


### PR DESCRIPTION
## Summary

- Add `parameters_b` (billion parameters) and `publish_date` (YYYY-MM) fields to all 25 models in `models.yaml`
- Values sourced from official announcements; MoE models use total parameter count with active count in comments
- Extend `load_model_metadata()` in `colors.py` to expose these new fields
- Add two new analysis plots in `basic_metrics.py`:
  - `score_vs_parameters.png/json`: performance vs model size (log scale, models with known params only)
  - `score_vs_publish_date.png/json`: performance vs release date (models with known date only)

## Test plan

- [x] `uv run python -c "from eleusis.analysis.basic_metrics import plot_score_vs_parameters, plot_score_vs_publish_date"` imports cleanly
- [x] `load_model_metadata()` returns correct `parameters_b` and `publish_date` for all models
- [x] Full analysis run on 7 SLM results generates both new plots without errors

Closes #5